### PR TITLE
Fix GitHub Actions workflow for .NET 9

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-mushroom-0c291f110.yml
+++ b/.github/workflows/azure-static-web-apps-orange-mushroom-0c291f110.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.401'
+          dotnet-version: '9.0.x'
 
       - name: generate statiq site
         run: |


### PR DESCRIPTION
## Summary
Fix deployment failure by updating GitHub Actions workflow to use .NET 9 SDK

## Problem
The previous PR updated the project to target .NET 9, but the GitHub Actions workflow was still using .NET 6 SDK, causing the deployment to fail.

## Solution
Update the workflow to install .NET 9.x SDK instead of .NET 6.0.401

🤖 Generated with [Claude Code](https://claude.ai/code)