### PR TITLE
Revert to .NET 6 for deployment

### DIFF
--- a/.github/workflows/azure-static-web-apps-orange-mushroom-0c291f110.yml
+++ b/.github/workflows/azure-static-web-apps-orange-mushroom-0c291f110.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dotnet
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '6.0.401'
 
       - name: generate statiq site
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <LangVersion>preview</LangVersion>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
     <Nullable>enable</Nullable>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Revert to .NET 6 to fix deployment hanging issue

## Problem
After updating to .NET 9, the deployment was hanging indefinitely during the statiq site generation step.

## Solution
Revert back to .NET 6 which was working properly before.

🤖 Generated with [Claude Code](https://claude.ai/code)